### PR TITLE
fixes a fatal B9PartSwitch exception due to a missing newline

### DIFF
--- a/GameData/RocketMotorMenagerie/Parts/rmm_arenysaurus.cfg
+++ b/GameData/RocketMotorMenagerie/Parts/rmm_arenysaurus.cfg
@@ -307,7 +307,8 @@ PART
 		switcherDescription = Engine Mount
 		switcherDescriptionPlural = Engine Mounts
         affectDragCubes = false
-        affectFARVoxels = false		SUBTYPE
+        affectFARVoxels = false
+	SUBTYPE
 		{
 			name = Compact
 			primaryColor=#707070


### PR DESCRIPTION
A previous change appears to have removed a newline, causing the file to become malformed and unreadable by B9PartSwitch. This fixes the issue described in https://github.com/EStreetRockets/RocketMotorMenagerie/issues/10.